### PR TITLE
Fix: Allow wildcards in metrics queries and improve queries parsing

### DIFF
--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -101,15 +101,15 @@ export function parseMetricQuery(query: string): {
 
     // Handle complex expressions with AND/OR and parentheses
     const normalizedContent = tagContent
-      .replace(/\s+AND\s+/g, ' AND ')
-      .replace(/\s+OR\s+/g, ' OR ')
+      .replace(/\s+AND\s+/gi, ' AND ') // Case-insensitive match for AND
+      .replace(/\s+OR\s+/gi, ' OR ') // Case-insensitive match for OR
 
     // Split by OR first
-    const orGroups = normalizedContent.split(' OR ')
+    const orGroups = normalizedContent.split(/ OR /i)
 
     orGroups.forEach((group) => {
       // Handle AND groups
-      const andGroups = group.split(' AND ')
+      const andGroups = group.split(/ AND /i)
 
       andGroups.forEach((tag) => {
         // Remove any parentheses
@@ -145,6 +145,7 @@ export function parseMetricQuery(query: string): {
  * - "env:prod,host:web-01" -> ["env:prod", "host:web-01"]
  * - "name:alb-1 OR name:alb-2 OR name:alb-3" -> ["name:alb-1", "name:alb-2", "name:alb-3"]
  * - "env:prod AND (name:alb-1 OR name:alb-2)" -> ["env:prod", "name:alb-1", "name:alb-2"]
+ * - "env:prod and (name:alb-1 or name:alb-2)" -> ["env:prod", "name:alb-1", "name:alb-2"]
  */
 function parseTagsWithOperators(tagsString: string): string[] {
   if (!tagsString.trim()) return []
@@ -176,15 +177,15 @@ function parseTagsWithOperators(tagsString: string): string[] {
       current = ''
     } else if (
       inParens === 0 &&
-      (tagsString.slice(i, i + 4) === ' OR ' ||
-        tagsString.slice(i, i + 5) === ' AND ')
+      (tagsString.slice(i, i + 4).toLowerCase() === ' or ' ||
+        tagsString.slice(i, i + 5).toLowerCase() === ' and ')
     ) {
-      // OR/AND operator
+      // OR/AND operator (case insensitive)
       if (current.trim()) {
         tags.push(...extractTagsFromExpression(current.trim()))
       }
       // Skip the operator
-      i += tagsString.slice(i, i + 4) === ' OR ' ? 3 : 4 // Skip " OR" or " AND"
+      i += tagsString.slice(i, i + 4).toLowerCase() === ' or ' ? 3 : 4
       current = ''
     } else {
       current += char

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -22,32 +22,222 @@ export function unreachable(value: never): never {
 }
 
 /**
- * Parses a Datadog metrics query string and extracts the metric name and tags.
- * Example query: 'avg:system.cpu.user{env:prod,host:web-01}'
- * Returns: { metric: 'system.cpu.user', tags: ['env:prod', 'host:web-01'] }
+ * Parses a Datadog metric query string into its components.
+ * Handles various query patterns including:
+ * - Simple metrics: 'system.cpu.user{*}'
+ * - Aggregation functions: 'avg:system.cpu.user{*}'
+ * - Complex functions: 'sum(last_5m):sum:aws.applicationelb.httpcode_elb_5xx{*}'
+ * - Tag filtering: 'metric{tag:value OR tag:value2}'
+ * - Arithmetic: 'avg:metric{*} * 100'
+ * - Time shifts: 'avg:metric{*}.rollup(sum, 30) / timeshift(avg:metric{*}, -1d)'
+ * - Advanced tag filters: 'metric{service:web-*} - metric{service!~web-api}'
+ *
+ * @param query - The metric query string to parse
+ * @returns Object containing the metric name and array of tags
  */
 export function parseMetricQuery(query: string): {
-  metric: string | null
+  metric: string
   tags: string[]
 } {
-  // Remove any function prefix (e.g., avg:) if present
-  let metricAndTags = query
-  const colonIdx = query.indexOf(':')
-  if (colonIdx !== -1) {
-    const braceIdx = query.indexOf('{')
-    if (braceIdx === -1 || colonIdx < braceIdx) {
-      metricAndTags = query.slice(colonIdx + 1)
+  if (!query) {
+    return { metric: '', tags: [] }
+  }
+
+  // Extract the metric name first
+  let metric = ''
+
+  // Remove any arithmetic operations and their operands after the first metric
+  const arithmeticSplit = query.split(/[\s]*[+\-*/][\s]*/)
+  const firstPart = arithmeticSplit[0]
+
+  // Handle time-shift and rollup functions
+  const functionPattern =
+    /^(?:(?:timeshift|rollup|sum|avg|min|max|count)\([^)]+\):)*([^{]+)/
+  const metricMatch = firstPart.match(functionPattern)
+
+  if (metricMatch) {
+    // Find the last colon before any tags or operators
+    const parts = metricMatch[1].split(':')
+    metric = parts[parts.length - 1].trim()
+  } else {
+    // If no function pattern found, use everything before the first brace or operator
+    const simpleSplit = firstPart.split('{')[0]
+    metric = simpleSplit.trim()
+  }
+
+  // If no braces in query, return empty tags
+  if (!query.includes('{')) {
+    return { metric, tags: [] }
+  }
+
+  // Extract tags from the query
+  const tags: string[] = []
+  const tagRegex = /{([^}]*)}/g
+  const tagMatches = query.match(tagRegex)
+
+  if (!tagMatches) {
+    return { metric, tags: [] }
+  }
+
+  // Process each tag group (inside braces)
+  for (const tagMatch of tagMatches) {
+    // Skip 'by' grouping tags
+    if (
+      query.includes(' by ') &&
+      query.indexOf(tagMatch) > query.indexOf(' by ')
+    ) {
+      continue
+    }
+
+    // Remove the braces
+    const tagContent = tagMatch.slice(1, -1).trim()
+
+    if (!tagContent || tagContent === '*') {
+      if (!tags.includes('*')) {
+        tags.push('*')
+      }
+      continue
+    }
+
+    // Handle complex expressions with AND/OR and parentheses
+    const normalizedContent = tagContent
+      .replace(/\s+AND\s+/g, ' AND ')
+      .replace(/\s+OR\s+/g, ' OR ')
+
+    // Split by OR first
+    const orGroups = normalizedContent.split(' OR ')
+
+    orGroups.forEach((group) => {
+      // Handle AND groups
+      const andGroups = group.split(' AND ')
+
+      andGroups.forEach((tag) => {
+        // Remove any parentheses
+        const cleanTag = tag.replace(/[()]/g, '').trim()
+
+        // Handle comma-separated tags
+        const commaTags = cleanTag.split(',')
+        commaTags.forEach((commaTag) => {
+          const trimmedTag = commaTag.trim()
+          if (trimmedTag && trimmedTag !== '*') {
+            // Don't add duplicates
+            if (!tags.includes(trimmedTag)) {
+              tags.push(trimmedTag)
+            }
+          }
+        })
+      })
+    })
+  }
+
+  // If no tags were found but braces were present, use wildcard
+  if (tags.length === 0 && query.includes('{')) {
+    tags.push('*')
+  }
+
+  return { metric, tags }
+}
+
+/**
+ * Parses tag expressions that may contain OR and AND operators.
+ * Extracts individual tag key:value pairs while preserving operator context.
+ * Examples:
+ * - "env:prod,host:web-01" -> ["env:prod", "host:web-01"]
+ * - "name:alb-1 OR name:alb-2 OR name:alb-3" -> ["name:alb-1", "name:alb-2", "name:alb-3"]
+ * - "env:prod AND (name:alb-1 OR name:alb-2)" -> ["env:prod", "name:alb-1", "name:alb-2"]
+ */
+function parseTagsWithOperators(tagsString: string): string[] {
+  if (!tagsString.trim()) return []
+
+  // If it's just a wildcard, return it
+  if (tagsString.trim() === '*') return ['*']
+
+  const tags: string[] = []
+
+  // Split by common operators and delimiters
+  // Handle both comma separation and logical operators
+  let current = ''
+  let inParens = 0
+
+  for (let i = 0; i < tagsString.length; i++) {
+    const char = tagsString[i]
+
+    if (char === '(') {
+      inParens++
+      current += char
+    } else if (char === ')') {
+      inParens--
+      current += char
+    } else if (char === ',' && inParens === 0) {
+      // Comma separator (traditional)
+      if (current.trim()) {
+        tags.push(...extractTagsFromExpression(current.trim()))
+      }
+      current = ''
+    } else if (
+      inParens === 0 &&
+      (tagsString.slice(i, i + 4) === ' OR ' ||
+        tagsString.slice(i, i + 5) === ' AND ')
+    ) {
+      // OR/AND operator
+      if (current.trim()) {
+        tags.push(...extractTagsFromExpression(current.trim()))
+      }
+      // Skip the operator
+      i += tagsString.slice(i, i + 4) === ' OR ' ? 3 : 4 // Skip " OR" or " AND"
+      current = ''
+    } else {
+      current += char
     }
   }
-  // Extract metric name and tags
-  const metricMatch = metricAndTags.match(/^([^{]+)(?:\{([^}]*)\})?$/)
-  if (!metricMatch) return { metric: null, tags: [] }
-  const metric = metricMatch[1].trim()
-  const tags = metricMatch[2]
-    ? metricMatch[2]
-        .split(',')
-        .map((t) => t.trim())
-        .filter(Boolean)
-    : []
-  return { metric, tags }
+
+  // Add the last part
+  if (current.trim()) {
+    tags.push(...extractTagsFromExpression(current.trim()))
+  }
+
+  // Remove duplicates and filter out empty strings
+  return Array.from(new Set(tags.filter((tag) => tag.trim() !== '')))
+}
+
+/**
+ * Extracts tag key:value pairs from a single expression.
+ * Handles parentheses and nested expressions.
+ */
+function extractTagsFromExpression(expression: string): string[] {
+  // Remove outer parentheses if they wrap the entire expression
+  let expr = expression.trim()
+  while (expr.startsWith('(') && expr.endsWith(')')) {
+    let parenCount = 0
+    let isWrapped = true
+    for (let i = 0; i < expr.length; i++) {
+      if (expr[i] === '(') parenCount++
+      if (expr[i] === ')') parenCount--
+      if (parenCount === 0 && i < expr.length - 1) {
+        isWrapped = false
+        break
+      }
+    }
+    if (isWrapped) {
+      expr = expr.slice(1, -1).trim()
+    } else {
+      break
+    }
+  }
+
+  // If this looks like a single tag (contains :), return it
+  if (expr.includes(':') && !expr.includes(' OR ') && !expr.includes(' AND ')) {
+    return [expr]
+  }
+
+  // If it contains operators, recursively parse
+  if (expr.includes(' OR ') || expr.includes(' AND ')) {
+    return parseTagsWithOperators(expr)
+  }
+
+  // Fallback: split by comma
+  return expr
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean)
 }

--- a/tests/utils/tool.test.ts
+++ b/tests/utils/tool.test.ts
@@ -185,4 +185,20 @@ describe('parseMetricQuery', () => {
     expect(result.metric).toBe('system.cpu.user')
     expect(result.tags).toEqual(['service:web-*', 'service!~api-*', 'env:prod'])
   })
+
+  it('parses tags with lowercase and/or operators', () => {
+    const result = parseMetricQuery(
+      'system.cpu.user{env:prod and (name:alb-1 or name:alb-2)}',
+    )
+    expect(result.metric).toBe('system.cpu.user')
+    expect(result.tags).toEqual(['env:prod', 'name:alb-1', 'name:alb-2'])
+  })
+
+  it('parses tags with mixed-case and/or operators', () => {
+    const result = parseMetricQuery(
+      'system.cpu.user{env:prod And (name:alb-1 oR name:alb-2)}',
+    )
+    expect(result.metric).toBe('system.cpu.user')
+    expect(result.tags).toEqual(['env:prod', 'name:alb-1', 'name:alb-2'])
+  })
 })


### PR DESCRIPTION
This branch fixes the `query_metrics` tool to allow the wildcard `*`, which made the tool fail and send an error before the fix.

In addition, the query parsing was improved to also identify different datadog metric query syntax operations (like the AND/OR operators) so it can correctly parse the tags used inside a query and validate each.